### PR TITLE
Fold converged design (Variant A) into production

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
   "dependencies": {
     "@astrojs/check": "^0.9.10",
     "@astrojs/solid-js": "^7.0.2",
-    "@tailwindcss/forms": "^0.5.11",
-    "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.1",
     "solid-js": "^1.9.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,6 @@ importers:
       '@astrojs/solid-js':
         specifier: ^7.0.2
         version: 7.0.2(esbuild@0.28.2)(jiti@2.7.0)(solid-js@1.9.14)(supports-color@10.2.2)(yaml@2.9.0)
-      '@tailwindcss/forms':
-        specifier: ^0.5.11
-        version: 0.5.11(tailwindcss@4.3.3)
-      '@tailwindcss/typography':
-        specifier: ^0.5.20
-        version: 0.5.20(tailwindcss@4.3.3)
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -822,11 +816,6 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@tailwindcss/forms@0.5.11':
-    resolution: {integrity: sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
-
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -915,11 +904,6 @@ packages:
   '@tailwindcss/oxide@4.3.3':
     resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
-
-  '@tailwindcss/typography@0.5.20':
-    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
   '@tailwindcss/vite@4.3.3':
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
@@ -1155,11 +1139,6 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
@@ -1602,10 +1581,6 @@ packages:
   micromark-util-types@2.0.1:
     resolution: {integrity: sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==}
 
-  mini-svg-data-uri@1.4.4:
-    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
-    hasBin: true
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1694,10 +1669,6 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
-
-  postcss-selector-parser@6.0.10:
-    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
-    engines: {node: '>=4'}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -1996,9 +1967,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validate-html-nesting@1.2.2:
     resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
@@ -2908,11 +2876,6 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@4.3.3)':
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 4.3.3
-
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2973,11 +2936,6 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.3.3
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
-
-  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.3)':
-    dependencies:
-      postcss-selector-parser: 6.0.10
-      tailwindcss: 4.3.3
 
   '@tailwindcss/vite@4.3.3(vite@8.2.1(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
@@ -3306,8 +3264,6 @@ snapshots:
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
-
-  cssesc@3.0.0: {}
 
   csso@5.0.5:
     dependencies:
@@ -3714,8 +3670,6 @@ snapshots:
 
   micromark-util-types@2.0.1: {}
 
-  mini-svg-data-uri@1.4.4: {}
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -3786,11 +3740,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.5: {}
-
-  postcss-selector-parser@6.0.10:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
   postcss@8.5.26:
     dependencies:
@@ -4084,8 +4033,6 @@ snapshots:
       browserslist: 4.24.2
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  util-deprecate@1.0.2: {}
 
   validate-html-nesting@1.2.2: {}
 

--- a/src/components/Jaculatorias.astro
+++ b/src/components/Jaculatorias.astro
@@ -1,68 +1,91 @@
-<h2>Jaculatorias</h2>
-<p>
-    <strong>Guía:</strong> Oh Soberano Santuario, Sagrario del Verbo Eterno...
-    <br />
-    <strong>Todos:</strong> Libra, Virgen, del infierno a los que rezan tu
-    Rosario.
-</p>
-<p>
-    <strong>Guía:</strong> Emperatriz poderosa de los mortales consuelo...
-    <br />
-    <strong>Todos:</strong> Ábrenos, Virgen el cielo con una muerte dichosa.
-</p>
-<p>
-    <strong>Guía:</strong> Padre nuestro, que estas en cielo, santificado sea
-    tu Nombre; venga a nosotros tu reino; hágase tu voluntad en la tierra como
-    en el cielo...
-    <br />
-    <strong>Todos:</strong> Danos hoy nuestro pan de cada día, perdona
-    nuestras ofensas, como también nosotros perdonamos a los que nos ofenden,
-    no nos dejes caer en la tentación y líbranos del mal.
-</p>
-<p>
-    <strong>Guía:</strong> Dios te salve, María Santísima, hija de Dios Padre,
-    Virgen Purísima y castísima antes del parto, en tus manos encomiendo toda
-    mi fe para que la alumbres, llena eres de gracia, el Señor está contigo,
-    bendita eres entre las mujeres y bendito es el fruto de tu vientre,
-    Jesús...
-    <br />
-    <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
-    pecadores, ahora y en la hora de nuestra muerte. Amén.
-</p>
-<p>
-    <strong>Guía:</strong> Dios te salve, María Santísima, madre de Dios Hijo,
-    Virgen Purísima y castísima en el parto, en tus manos encomiendo mi
-    esperanza para que la alientes, llena eres de gracia, el Señor está
-    contigo, bendita eres entre las mujeres y bendito es el fruto de tu
-    vientre, Jesús...
-    <br />
-    <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
-    pecadores, ahora y en la hora de nuestra muerte. Amén.
-</p>
-<p>
-    <strong>Guía:</strong> Dios te salve, María Santísima, esposa de Dios
-    Espíritu Santo, Virgen Purísima y castísima después del parto, en tus manos
-    encomiendo mi caridad para que la inflames, llena eres de gracia, el Señor
-    está contigo, bendita eres entre las mujeres y bendito es el fruto de tu
-    vientre, Jesús...
-    <br />
-    <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
-    pecadores, ahora y en la hora de nuestra muerte. Amén.
-</p>
-<p>
-    <strong>Guía:</strong> Dios te salve, María Santísima, templo, trono y
-    sagrario de la Santísima Trinidad, Virgen concebida sin culpa original,
-    Dios te salve...
-    <br />
-    <strong>Todos:</strong> Reina y Madre, Madre de misericordia, vida, dulzura y
-    esperanza nuestra: Dios te salve; a ti llamamos los desterrados hijos de
-    Eva; a ti suspiramos gimiendo y llorando en este valle de lágrimas. ¡Ea!,
-    Pues, Señora, abogada nuestra, vuelve a nosotros esos tus ojos
-    misericordiosos y después, de este destierro muéstranos a Jesús fruto
-    bendito de tu vientre, ¡Oh clemente! ¡Oh piadosa! ¡Oh dulce Virgen María!.
-</p>
-<p>
-    <strong>Guía:</strong> Ruega por nosotros, Santa, Madre de Dios, para que
-    seamos dignos de alcanzar las divinas gracias y promesas de nuestro señor
-    Jesucristo, Amén.
-</p>
+<h2 class="section-title">Jaculatorias</h2>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Oh Soberano Santuario, Sagrario del Verbo Eterno...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Libra, Virgen, del infierno a los que rezan tu
+        Rosario.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Emperatriz poderosa de los mortales consuelo...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Ábrenos, Virgen el cielo con una muerte dichosa.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Padre nuestro, que estas en cielo, santificado sea
+        tu Nombre; venga a nosotros tu reino; hágase tu voluntad en la tierra como
+        en el cielo...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Danos hoy nuestro pan de cada día, perdona
+        nuestras ofensas, como también nosotros perdonamos a los que nos ofenden,
+        no nos dejes caer en la tentación y líbranos del mal.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Dios te salve, María Santísima, hija de Dios Padre,
+        Virgen Purísima y castísima antes del parto, en tus manos encomiendo toda
+        mi fe para que la alumbres, llena eres de gracia, el Señor está contigo,
+        bendita eres entre las mujeres y bendito es el fruto de tu vientre,
+        Jesús...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
+        pecadores, ahora y en la hora de nuestra muerte. Amén.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Dios te salve, María Santísima, madre de Dios Hijo,
+        Virgen Purísima y castísima en el parto, en tus manos encomiendo mi
+        esperanza para que la alientes, llena eres de gracia, el Señor está
+        contigo, bendita eres entre las mujeres y bendito es el fruto de tu
+        vientre, Jesús...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
+        pecadores, ahora y en la hora de nuestra muerte. Amén.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Dios te salve, María Santísima, esposa de Dios
+        Espíritu Santo, Virgen Purísima y castísima después del parto, en tus
+        manos encomiendo mi caridad para que la inflames, llena eres de gracia,
+        el Señor está contigo, bendita eres entre las mujeres y bendito es el
+        fruto de tu vientre, Jesús...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
+        pecadores, ahora y en la hora de nuestra muerte. Amén.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Dios te salve, María Santísima, templo, trono y
+        sagrario de la Santísima Trinidad, Virgen concebida sin culpa original,
+        Dios te salve...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Reina y Madre, Madre de misericordia, vida, dulzura
+        y esperanza nuestra: Dios te salve; a ti llamamos los desterrados hijos
+        de Eva; a ti suspiramos gimiendo y llorando en este valle de lágrimas.
+        ¡Ea!, Pues, Señora, abogada nuestra, vuelve a nosotros esos tus ojos
+        misericordiosos y después, de este destierro muéstranos a Jesús fruto
+        bendito de tu vientre, ¡Oh clemente! ¡Oh piadosa! ¡Oh dulce Virgen María!.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Ruega por nosotros, Santa, Madre de Dios, para que
+        seamos dignos de alcanzar las divinas gracias y promesas de nuestro señor
+        Jesucristo, Amén.
+    </p>
+</div>

--- a/src/components/Letanias.astro
+++ b/src/components/Letanias.astro
@@ -1,289 +1,232 @@
-<h2>Letanías</h2>
-<ul class="list-outside space-y-4">
-    <li>
+<h2 class="section-title">Letanías</h2>
+<ul class="list-none space-y-5">
+    <li class="litany-item">
         Señor, ten piedad de nosotros.
-        <br />
         <strong>Señor, ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Cristo, ten piedad de nosotros.
-        <br />
         <strong>Cristo, ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Señor, ten piedad de nosotros.
-        <br />
         <strong>Señor, ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Cristo, óyenos.
-        <br />
         <strong>Cristo, óyenos.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Cristo, escúchanos.
-        <br />
         <strong>Cristo, escúchanos.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Dios Padre celestial.
-        <br />
         <strong>Ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Dios Hijo Redentor del mundo.
-        <br />
         <strong>Ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Dios Espíritu Santo.
-        <br />
         <strong>Ten piedad de nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Santísima Trinidad que eres un solo Dios.
-        <br />
         <strong>Ten piedad de nosotros.</strong>
     </li>
 
-    <li>
+    <li class="litany-item">
         Santa María.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Santa Madre de Dios.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Santa Virgen de las vírgenes.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre de Jesucristo.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre de la Iglesia.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre de la divina Gracia.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Purísima.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Castísima.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Virgen.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Inmaculada.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Amable.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre Admirable.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre del buen Consejo.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre del Creador.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Madre del Salvador.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Virgen Prudentísima.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Virgen Venerable.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Virgen Clemente.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Virgen Poderosa.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Virgen Fiel.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Espejo de Justicia.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Trono de Sabiduría.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Causa de nuestra Alegría.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Vaso Espiritual.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Vaso Honorable.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Vaso insigne de Devoción.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Rosa Mística.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Torre de David.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Casa de Oro.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Arca de la Alianza.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Puerta del Cielo.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Estrella de la Mañana.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Salud de los enfermos.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Consolador de los Afligidos.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Refugio de los pecadores.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Auxilio de los cristianos.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Ángeles.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Patriarcas.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Profetas.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Apóstoles.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Mártires.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de los Confesores.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de las Vírgenes.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de todos los Santos.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina concebida sin pecado original.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina elevada al cielo.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina del Santo Rosario.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
-    <li>
+    <li class="litany-item">
         Reina de la Paz.
-        <br />
         <strong>Ruega por nosotros.</strong>
     </li>
 </ul>

--- a/src/components/Misterios.tsx
+++ b/src/components/Misterios.tsx
@@ -1,128 +1,120 @@
-import {createSignal, createMemo, For, onMount, Show} from "solid-js";
+import { createSignal, For, onMount, Show } from "solid-js"
 
 interface MisterioSet {
-  label: string
-  days: readonly string[]
-  items: readonly string[]
+    label: string
+    days: readonly string[]
+    items: readonly string[]
 }
 
 const misterios = {
-  'gozosos': {
-    label: 'Misterios Gozosos (Lunes y Sábado)',
-    days: ['Monday', 'Saturday'],
-    items: [
-      'El anuncio del Ángel a María.',
-      'La visita de la Santísima Virgen a Santa Isabel.',
-      'El nacimiento de Jesús en el portal de Belén.',
-      'La presentación de Jesús en el templo.',
-      'Jesús perdido y hallado en el templo.',
-    ]
-  },
-  'luminosos': {
-    label: 'Misterios Luminosos (Jueves)',
-    days: ['Thursday'],
-    items: [
-      'El Bautismo de Cristo en el Jordán.',
-      'Su auto revelación en las bodas de Caná.',
-      'El anuncio del Reino y llamado a la conversión.',
-      'La Transfiguración del Señor.',
-      'La Institución de la Eucaristía.',
-    ]
-  },
-  'dolorosos': {
-    label: 'Misterios Dolorosos (Martes y Viernes)',
-    days: ['Tuesday', 'Friday'],
-    items: [
-      'La oración de Jesús en el Huerto.',
-      'La flagelación de Jesús.',
-      'Jesús es coronado de espinas.',
-      'Jesús con la Cruz a cuestas.',
-      'La crucifixión y muerte de Jesús.',
-    ]
-  },
-  'gloriosos': {
-    label: 'Misterios Gloriosos (Miércoles y Domingo)',
-    days: ['Wednesday', 'Sunday'],
-    items: [
-      'La Resurrección de Nuestro Señor Jesucristo.',
-      'La Ascensión de Jesús al Cielo.',
-      'La venida del Espíritu Santo.',
-      'La asunción de María al Cielo.',
-      'La coronación y glorificación de María.',
-    ]
-  },
-} as Record<string, MisterioSet>
+    gozosos: {
+        label: "Misterios Gozosos (Lunes y Sábado)",
+        days: ["Monday", "Saturday"],
+        items: [
+            "El anuncio del Ángel a María.",
+            "La visita de la Santísima Virgen a Santa Isabel.",
+            "El nacimiento de Jesús en el portal de Belén.",
+            "La presentación de Jesús en el templo.",
+            "Jesús perdido y hallado en el templo.",
+        ],
+    },
+    luminosos: {
+        label: "Misterios Luminosos (Jueves)",
+        days: ["Thursday"],
+        items: [
+            "El Bautismo de Cristo en el Jordán.",
+            "Su auto revelación en las bodas de Caná.",
+            "El anuncio del Reino y llamado a la conversión.",
+            "La Transfiguración del Señor.",
+            "La Institución de la Eucaristía.",
+        ],
+    },
+    dolorosos: {
+        label: "Misterios Dolorosos (Martes y Viernes)",
+        days: ["Tuesday", "Friday"],
+        items: [
+            "La oración de Jesús en el Huerto.",
+            "La flagelación de Jesús.",
+            "Jesús es coronado de espinas.",
+            "Jesús con la Cruz a cuestas.",
+            "La crucifixión y muerte de Jesús.",
+        ],
+    },
+    gloriosos: {
+        label: "Misterios Gloriosos (Miércoles y Domingo)",
+        days: ["Wednesday", "Sunday"],
+        items: [
+            "La Resurrección de Nuestro Señor Jesucristo.",
+            "La Ascensión de Jesús al Cielo.",
+            "La venida del Espíritu Santo.",
+            "La asunción de María al Cielo.",
+            "La coronación y glorificación de María.",
+        ],
+    },
+} satisfies Record<string, MisterioSet>
 
 type MisteriosValidos = keyof typeof misterios
 
-function useMisterios() {
-  const [selected, setSelected] = createSignal<MisteriosValidos | undefined>()
-
-  const selectedMisterio = createMemo(() => {
-    if (!selected() || !(selected()! in misterios)) return undefined
-
-    return misterios[selected()!]
-  })
-
-  function selectByLabel(key: MisteriosValidos) {
-    setSelected(key in misterios ? key : undefined)
-  }
-
-  function selectByDay(day: string) {
-    setSelected(
-        Object.keys(misterios)
-            .find((key) => misterios[key].days.includes(day))
+// Data day names are English ("Monday", ...); timezone is the visitor's.
+const todaysKey = (): MisteriosValidos | undefined =>
+    (Object.keys(misterios) as MisteriosValidos[]).find((key) =>
+        misterios[key].days.includes(
+            new Date().toLocaleString("en-US", { weekday: "long" })
+        )
     )
-  }
-
-  function selectToday() {
-    selectByDay(
-        new Date().toLocaleString('en-US', {
-          weekday: 'long'
-        })
-    )
-  }
-
-  return {
-    selectedKey: selected,
-    selected: selectedMisterio,
-    selectByLabel,
-    selectToday
-  }
-}
 
 export default function () {
-  const { selected, selectedKey, selectByLabel, selectToday } = useMisterios()
+    const [openKey, setOpenKey] = createSignal<MisteriosValidos | undefined>()
 
-  onMount(() => selectToday())
+    onMount(() => setOpenKey(todaysKey()))
 
-  return (
-      <>
-        <h2>Lectura de los Misterios</h2>
-
-        <select
-            class="dark:bg-black mt-2"
-            onChange={(e) => selectByLabel(e.currentTarget.value)}
-        >
-          <option disabled selected={!selectedKey()}>Selecciona los Misterios por Leer</option>
-          <For each={Object.entries(misterios)}>
-            {([value, {label}]) => (
-                <option value={value} selected={selectedKey() === value}>
-                  {label}
-                </option>
-            )}
-          </For>
-        </select>
-
-        <Show when={selected()}>
-          <ul>
-            <For each={selected()!.items}>
-              {(misterio) => (
-                  <li>{misterio}</li>
-              )}
+    return (
+        <>
+            <h2 class="section-title">Lectura de los Misterios</h2>
+            <p class="mb-4 text-lg text-stone-500 dark:text-stone-400">
+                Se rezan según el día de la semana.
+            </p>
+            <For each={Object.entries(misterios) as [MisteriosValidos, MisterioSet][]}>
+                {([key, set]) => (
+                    <details
+                        open={openKey() === key}
+                        class={`group relative mb-4 rounded-xl border-2 ${openKey() === key
+                                ? "border-amber-500/70 bg-amber-50/60 dark:bg-amber-950/20"
+                                : "border-stone-200 bg-white dark:border-stone-700 dark:bg-stone-900"
+                            }`}
+                    >
+                        <Show when={key === todaysKey()}>
+                            <span class="absolute -top-2 right-4 rounded-full bg-amber-500 px-3 py-0.5 text-xs font-bold uppercase tracking-wide text-stone-900 shadow">
+                                Hoy
+                            </span>
+                        </Show>
+                        <summary
+                            class="flex min-h-[64px] cursor-pointer list-none items-center justify-between px-5 py-4 text-xl font-semibold text-stone-800 dark:text-stone-100"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                setOpenKey(openKey() === key ? undefined : key)
+                            }}
+                        >
+                            <span>{set.label}</span>
+                            <span
+                                aria-hidden="true"
+                                class="text-2xl text-teal-700 transition-transform group-open:rotate-90 dark:text-teal-300"
+                            >
+                                ›
+                            </span>
+                        </summary>
+                        <ol class="mx-12 mb-4 list-decimal space-y-1.5 border-stone-300 text-xl leading-relaxed text-stone-700 dark:border-teal-400/40 dark:text-white">
+                            <For each={set.items}>
+                                {(item) => <li class="mt-1.5">{item}</li>}
+                            </For>
+                        </ol>
+                        <p class="mx-5 mb-4 rounded-lg bg-amber-50 px-4 py-3 text-base text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+                            <strong>Nota:</strong> en cada misterio se reza un Padre
+                            Nuestro y diez Ave Marías.
+                        </p>
+                    </details>
+                )}
             </For>
-          </ul>
-        </Show>
-      </>
-  )
+        </>
+    )
 }

--- a/src/components/OracionFinal.astro
+++ b/src/components/OracionFinal.astro
@@ -1,33 +1,42 @@
-<h2>Oración Final</h2>
-<p>
-    <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
-    <br />
-    <strong>Todos:</strong> Perdónanos Señor.
-</p>
-<p>
-    <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
-    <br />
-    <strong>Todos:</strong> Óyenos Señor.
-</p>
-<p>
-    <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
-    <br />
-    <strong>Todos:</strong> Ten piedad y misericordia de nosotros.
-</p>
-<p>
-    <strong>Guía:</strong> Bajo tu amparo nos acogemos, Santa Madre de Dios,
-    no desprecies las súplicas que te hacemos en nuestras necesidades, antes
-    bien, líbranos de todos los peligros, oh Virgen gloriosa y bendita. Ruega
-    por nosotros, Santa Madre de Dios...
-    <br />
-    <strong>Todos:</strong> Para que seamos dignos de alcanzar las promesas de
-    Nuestro Señor Jesucristo. Amén.
-</p>
-<p>
-    <strong>Guía:</strong> Oh Dios, cuyo Unigénito Hijo, con su vida, muerte y
-    resurrección, nos alcanzó el premio de la vida eterna: concédenos, a los
-    que recordamos estos misterios del Santo Rosario, imitar lo que contienen
-    y alcanzar lo que prometen. Por el mismo Jesucristo, nuestro Señor.
-    <br />
-    <strong>Todos:</strong> Amén.
-</p>
+<h2 class="section-title">Oración Final</h2>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
+    </p>
+    <p class="line-todos"><strong>Todos:</strong> Perdónanos Señor.</p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
+    </p>
+    <p class="line-todos"><strong>Todos:</strong> Óyenos Señor.</p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Cordero de Dios que quitas el pecado del mundo.
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Ten piedad y misericordia de nosotros.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Bajo tu amparo nos acogemos, Santa Madre de Dios,
+        no desprecies las súplicas que te hacemos en nuestras necesidades, antes
+        bien, líbranos de todos los peligros, oh Virgen gloriosa y bendita. Ruega
+        por nosotros, Santa Madre de Dios...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Para que seamos dignos de alcanzar las promesas de
+        Nuestro Señor Jesucristo. Amén.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Oh Dios, cuyo Unigénito Hijo, con su vida, muerte y
+        resurrección, nos alcanzó el premio de la vida eterna: concédenos, a los
+        que recordamos estos misterios del Santo Rosario, imitar lo que contienen
+        y alcanzar lo que prometen. Por el mismo Jesucristo, nuestro Señor.
+    </p>
+    <p class="line-todos"><strong>Todos:</strong> Amén.</p>
+</div>

--- a/src/components/OracionInicial.astro
+++ b/src/components/OracionInicial.astro
@@ -1,21 +1,24 @@
-<h2>Oración Inicial</h2>
-<p>
-    <strong>Guía:</strong> Por la Señal de la Santa Cruz, de nuestros
-    enemigos libranos Señor, Dios nuestro. En el nombre del Padre, del Hijo y
-    del Espíritu Santo.
-    <br />
-    <strong>Todos:</strong> Amén.
-</p>
+<h2 class="section-title">Oración Inicial</h2>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Por la Señal de la Santa Cruz, de nuestros
+        enemigos libranos Señor, Dios nuestro. En el nombre del Padre, del Hijo y
+        del Espíritu Santo.
+    </p>
+    <p class="line-todos"><strong>Todos:</strong> Amén.</p>
+</div>
 
-<p>
-    <strong>Todos:</strong> Señor mío Jesucristo, Dios y Hombre verdadero,
-    creador y redentor mío, por ser tú quien eres y porque te amo sobre todas
-    las cosas, me pesa de todo corazón haberte ofendido. Propongo firmemente
-    enmendarme, confesarme y cumplir la penitencia que me fuese impuesta,
-    ofrezco mi vida, obras y trabajos en satisfacción de mis pecados.
-    <br />
-    Confío en tu bondad y misericordia infinita que me perdonarás por tu
-    preciosa sangre, y me darás la gracia para nunca más pecar.
-    <br />
-    Amén.
-</p>
+<div class="mb-7">
+    <p class="line-todos">
+        <strong>Todos:</strong> Señor mío Jesucristo, Dios y Hombre verdadero,
+        creador y redentor mío, por ser tú quien eres y porque te amo sobre todas
+        las cosas, me pesa de todo corazón haberte ofendido. Propongo firmemente
+        enmendarme, confesarme y cumplir la penitencia que me fuese impuesta,
+        ofrezco mi vida, obras y trabajos en satisfacción de mis pecados.
+    </p>
+    <p class="line-plain">
+        Confío en tu bondad y misericordia infinita que me perdonarás por tu
+        preciosa sangre, y me darás la gracia para nunca más pecar.
+    </p>
+    <p class="line-plain">Amén.</p>
+</div>

--- a/src/components/OracionIntencionesSantoPadre.astro
+++ b/src/components/OracionIntencionesSantoPadre.astro
@@ -1,24 +1,33 @@
-<h2>Oración por las intenciones del Santo Padre</h2>
-<p>
-    <strong>Guía:</strong> Padre nuestro, que estas en cielo, santificado sea
-    tu Nombre; venga a nosotros tu reino; hágase tu voluntad en la tierra como
-    en el cielo...
-    <br />
-    <strong>Todos:</strong> Danos hoy nuestro pan de cada día, perdona
-    nuestras ofensas, como también nosotros perdonamos a los que nos ofenden,
-    no nos dejes caer en la tentación y líbranos del mal.
-</p>
-<p>
-    <strong>Guía:</strong> Alegrate María, llena eres de gracia, el Señor está
-    contigo, bendita eres entre las mujeres y bendito es el fruto de tu
-    vientre, Jesús...
-    <br />
-    <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
-    pecadores, ahora y en la hora de nuestra muerte. Amén.
-</p>
-<p>
-    <strong>Guía:</strong> Gloria al Padre, al Hijo y al Espíritu Santo...
-    <br />
-    <strong>Todos:</strong> Como era en el principio, ahora y siempre, por los
-    siglos de los siglos. Amén.
-</p>
+<h2 class="section-title">Oración por las intenciones del Santo Padre</h2>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Padre nuestro, que estas en cielo, santificado sea
+        tu Nombre; venga a nosotros tu reino; hágase tu voluntad en la tierra como
+        en el cielo...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Danos hoy nuestro pan de cada día, perdona
+        nuestras ofensas, como también nosotros perdonamos a los que nos ofenden,
+        no nos dejes caer en la tentación y líbranos del mal.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Alegrate María, llena eres de gracia, el Señor está
+        contigo, bendita eres entre las mujeres y bendito es el fruto de tu
+        vientre, Jesús...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Santa María Madre de Dios, ruega por nosotros los
+        pecadores, ahora y en la hora de nuestra muerte. Amén.
+    </p>
+</div>
+<div class="mb-7">
+    <p class="line-guia">
+        <strong>Guía:</strong> Gloria al Padre, al Hijo y al Espíritu Santo...
+    </p>
+    <p class="line-todos">
+        <strong>Todos:</strong> Como era en el principio, ahora y siempre, por los
+        siglos de los siglos. Amén.
+    </p>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,58 +1,85 @@
 ---
 import "../styles/global.css";
-
 import OracionInicial from "../components/OracionInicial.astro";
 import Misterios from "../components/Misterios.tsx";
 import OracionIntencionesSantoPadre from "../components/OracionIntencionesSantoPadre.astro";
 import Jaculatorias from "../components/Jaculatorias.astro";
 import Letanias from "../components/Letanias.astro";
 import OracionFinal from "../components/OracionFinal.astro";
-
 ---
 
 <html lang="es">
-<head>
-	<meta charset="utf-8" />
-	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-	<meta name="viewport" content="width=device-width" />
-	<meta name="generator" content={Astro.generator} />
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="generator" content={Astro.generator} />
+        <title>Guía del Santo Rosario</title>
+        <meta
+            property="og:title"
+            content="Guía para rezar el Santo Rosario de la Virgen de Guadalupe"
+        />
+        <meta
+            name="description"
+            content="Guía para rezar el Santo Rosario de la Virgen de Guadalupe"
+        />
+        <meta
+            property="og:description"
+            content="Guía para rezar el Santo Rosario de la Virgen de Guadalupe"
+        />
+        <meta property="og:url" content="https://rosario.jorgeglz.io" />
+        <meta
+            property="twitter:title"
+            content="Guía para rezar el Santo Rosario de la Virgen de Guadalupe"
+        />
+        <meta
+            property="twitter:description"
+            content="Guía para rezar el Santo Rosario de la Virgen de Guadalupe"
+        />
+    </head>
+    <body class="bg-[#faf6ee] text-stone-800 dark:bg-stone-950 dark:text-stone-100">
+        <main class="min-h-screen">
+            <div class="mx-auto max-w-3xl px-5 py-10 sm:px-8">
+                <header class="mb-10 text-center">
+                    <p class="text-sm font-bold uppercase tracking-[0.2em] text-teal-800 dark:text-teal-300">
+                        Guía para rezar
+                    </p>
+                    <h1 class="mt-2 font-serif text-5xl font-bold text-stone-900 sm:text-6xl dark:text-white">
+                        Santo Rosario
+                    </h1>
+                    <p class="mt-3 font-serif text-xl italic text-stone-500 dark:text-stone-400">
+                        «¿No estoy yo aquí, que soy tu Madre?»
+                    </p>
+                </header>
 
-	<title>Guía del Santo Rosario</title>
-	<meta name="og:title" content="Guía del Santo Rosario" />
+                <section class="mb-12">
+                    <OracionInicial />
+                </section>
+                <section class="mb-12">
+                    <Misterios client:load />
+                </section>
+                <section class="mb-12">
+                    <OracionIntencionesSantoPadre />
+                </section>
+                <section class="mb-12">
+                    <Jaculatorias />
+                </section>
+                <section class="mb-12">
+                    <Letanias />
+                </section>
+                <section class="mb-12">
+                    <OracionFinal />
+                </section>
 
-	<meta name="description" content="Guía web para rezar del Santo Rosario en cualquier lugar." />
-	<meta name="og:description" content="Guía web para rezar del Santo Rosario en cualquier lugar." />
-
-	<meta name="og:url" content={Astro.url} />
-
-	<meta name="twitter:site" content="@iksaku2" />
-	<meta name="twitter:creator" content="@iksaku2" />
-	<meta name="twitter:card" content="summary" />
-</head>
-	<body class="bg-white dark:bg-gray-900 text-black dark:text-white">
-		<div class="max-w-6xl px-8 mx-auto my-8">
-			<article class="prose prose-lg dark:prose-invert max-w-none">
-				<OracionInicial />
-				<Misterios client:load />
-				<OracionIntencionesSantoPadre />
-				<Jaculatorias />
-				<Letanias />
-				<OracionFinal />
-			</article>
-
-			<footer class="w-full my-8 flex items-center justify-center space-x-2 text-center text-base font-medium">
-				&copy;
-				<a
-					href="https://jorgeglz.io"
-					target="_blank"
-					class="underline decoration-2 decoration-blue-500"
-				>
-					Jorge González
-				</a>
-				<span>
-					2020 - {new Date().getFullYear()}
-				</span>
-			</footer>
-		</div>
-	</body>
+                <footer class="mt-14 border-t-2 border-stone-200 pt-6 text-center text-base text-stone-500 dark:border-stone-800 dark:text-stone-400">
+                    &copy; <a
+                        class="underline decoration-teal-600 decoration-2 underline-offset-2"
+                        href="https://jorgeglz.io"
+                        target="_blank"
+                        rel="noreferrer">Jorge González</a
+                    > 2020 – {new Date().getFullYear()}
+                </footer>
+            </div>
+        </main>
+    </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,30 @@
 @import "tailwindcss";
 
-@plugin "@tailwindcss/forms";
-@plugin "@tailwindcss/typography";
+.section-title {
+  @apply mb-6 border-b-2 border-teal-700/40 pb-2 font-serif text-2xl font-bold text-stone-900 sm:text-3xl dark:border-teal-400/40 dark:text-white;
+}
 
-/* Migrated from tailwind.config.mjs: tighten heading spacing inside prose */
-.prose :is(h1, h2, h3, h4, h5, h6) {
-  margin-bottom: 1rem !important;
+.line-guia {
+  @apply text-[1.35rem] leading-[1.9] font-semibold text-stone-800 sm:text-2xl dark:text-stone-100;
+}
+.line-guia > strong {
+  @apply text-teal-800 dark:text-teal-300;
+}
+
+.line-todos {
+  @apply pl-6 text-[1.35rem] leading-[1.9] text-stone-600 sm:pl-8 sm:text-2xl dark:text-stone-300;
+}
+.line-todos > strong {
+  @apply text-rose-800 dark:text-rose-300;
+}
+
+.line-plain {
+  @apply text-[1.35rem] leading-[1.9] text-stone-700 sm:text-2xl dark:text-stone-200;
+}
+
+.litany-item {
+  @apply border-l-4 border-rose-300 pl-4 text-[1.2rem] leading-relaxed text-stone-800 dark:border-rose-700 dark:text-stone-100;
+}
+.litany-item > strong {
+  @apply block font-semibold text-teal-800 dark:text-teal-300;
 }


### PR DESCRIPTION
Implements the winning direction from wayfinder convergence ([#31](https://github.com/iksaku/rosario-web/issues/31)) on the real codebase. Supersedes the prototype PR [#33](https://github.com/iksaku/rosario-web/pull/33); prototype preserved on `prototype/design-directions` as primary source.

- Variant A becomes the single design (no switcher, no prototype shell)
- Prayer texts verified byte-identical to `main` via extraction diff across all six components (incl. misterios data, 31/31 strings)
- Misterios: exclusive accordion, weekday auto-open + HOY badge, PN/AM note
- Removed unused `@tailwindcss/forms` and `@tailwindcss/typography`

Note: the prototype preview had stale paraphrases in Jaculatorias/OracionFinal/misterios items — this PR carries the real texts from main, verified mechanically.